### PR TITLE
Modify layout, add expandable backlog and side navigation

### DIFF
--- a/src/components/CreateEpicZoneForm.tsx
+++ b/src/components/CreateEpicZoneForm.tsx
@@ -21,7 +21,7 @@ const CreateEpicZoneForm = ({
       <form onSubmit={handleSubmit}>
         <div className="">
           <input
-            className=" placeholder-gray-500 mr-2 mb-1"
+            className=" placeholder-gray-500 mr-2 mb-1 text-sm"
             type="text"
             name="epicName"
             placeholder="New epic name"
@@ -29,12 +29,12 @@ const CreateEpicZoneForm = ({
             required
           />
           <input
-            className=" placeholder-gray-500 mr-2 mb-1"
+            className=" placeholder-gray-500 mr-2 mb-1 text-sm"
             type="number"
             name="priority"
             placeholder="Priority"
           />{' '}
-          <button className="btn btn-primary mr-2 w-full" type="submit">
+          <button className="btn btn-primary mr-2 w-full text-sm" type="submit">
             Add
           </button>
         </div>

--- a/src/components/CreateStoryZoneForm.tsx
+++ b/src/components/CreateStoryZoneForm.tsx
@@ -25,7 +25,7 @@ const CreateStoryZoneForm = ({
       <form onSubmit={handleSubmit}>
         <div className="">
           <input
-            className=" placeholder-gray-500 mr-2 mb-1"
+            className=" placeholder-gray-500 mr-2 mb-1 text-sm"
             type="text"
             name="description"
             placeholder="Description"
@@ -33,13 +33,13 @@ const CreateStoryZoneForm = ({
             required
           />
           <input
-            className="placeholder-gray-500 mr-2 mb-1"
+            className="placeholder-gray-500 mr-2 mb-1 text-sm"
             type="number"
             name="weight"
             placeholder="Weight"
           />{' '}
           <div className="relative">
-            <select className="" name="epic">
+            <select className="text-sm" name="epic">
               {epics &&
                 epics.map((epic, i) => {
                   const { id, name } = epic;
@@ -62,7 +62,7 @@ const CreateStoryZoneForm = ({
           </div>
         </div>
         <div className="mt-1">
-          <button className="btn btn-primary mr-2 w-full" type="submit">
+          <button className="btn btn-primary mr-2 w-full text-sm" type="submit">
             Add
           </button>
         </div>

--- a/src/components/Epic.tsx
+++ b/src/components/Epic.tsx
@@ -23,7 +23,7 @@ const Epic: React.FunctionComponent<IEpic & IEpicProps> = ({
           <div className="text-sm pr-1">{name}</div>
           <div className="text-sm">{priority}</div>
         </div>
-        <div className="px-4 flex-grow-0">
+        <div className="px-2 flex-grow-0">
           <div className="h-8 w-8 flex flex-row items-center justify-center">
             {isLoading ? (
               <Loader type="Grid" width={13} height={13} />

--- a/src/components/NotificationsList.tsx
+++ b/src/components/NotificationsList.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+import { INotification, STORY_REQUEST_ACTION } from 'types';
+
+const NotificationsList: React.FunctionComponent<{
+  notifications: INotification[];
+  onAcceptOrRejectStoryRequest?: (
+    storyRequestId: number,
+    action: STORY_REQUEST_ACTION,
+    note: string
+  ) => void;
+}> = ({ notifications, onAcceptOrRejectStoryRequest }) => {
+  const [inputNotes, setInputNotes] = useState({});
+
+  return (
+    <>
+      {notifications && notifications.length > 0 ? (
+        notifications.map((notification: INotification, i) => {
+          const {
+            storyRequestId,
+            epic,
+            sender: senderBoard,
+            notes,
+            points,
+            description,
+            sprint,
+          } = notification;
+          return (
+            <div key={i} className="border-b-2 border-dotted border-gray-200 pb-4 mb-4">
+              <div className="text-sm">
+                <span className="font-black">{senderBoard}</span> has requested to add a story "
+                <span className="font-black">{description}</span>" to this board in sprint{' '}
+                <span className="font-black">{sprint}</span>, epic{' '}
+                <span className="font-black">{epic}</span>
+              </div>{' '}
+              {notes && (
+                <div className="border-l-2 border-gray-500 pl-2 text-sm mt-2">
+                  Notes:
+                  <div>{notes}</div>
+                </div>
+              )}
+              <div className="mt-2">
+                <div>
+                  <input
+                    className="text-sm"
+                    placeholder="Notes (eg Rejecting because...)"
+                    onChange={e =>
+                      setInputNotes({
+                        ...inputNotes,
+                        [storyRequestId]: e.target.value,
+                      })
+                    }
+                  />
+                </div>
+                <div className="flex flex-row mt-2">
+                  <button
+                    className="btn btn-minimal text-sm w-1/2 mr-2"
+                    onClick={() =>
+                      onAcceptOrRejectStoryRequest(
+                        storyRequestId,
+                        STORY_REQUEST_ACTION.Reject,
+                        inputNotes[storyRequestId] || ''
+                      )
+                    }
+                  >
+                    Reject
+                  </button>
+                  <button
+                    className="btn btn-primary py-1 text-sm w-1/2"
+                    onClick={() =>
+                      onAcceptOrRejectStoryRequest(
+                        storyRequestId,
+                        STORY_REQUEST_ACTION.Accept,
+                        inputNotes[storyRequestId] || ''
+                      )
+                    }
+                  >
+                    Accept
+                  </button>
+                </div>
+              </div>
+            </div>
+          );
+        })
+      ) : (
+        <div className="italic text-teal-600 text-sm">No new notifications</div>
+      )}
+    </>
+  );
+};
+
+export default NotificationsList;

--- a/src/components/SideNavigation.tsx
+++ b/src/components/SideNavigation.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { NAVIGATION_LINKS } from 'types';
+import classnames from 'classnames';
+import { Bell, Zap, Users } from 'react-feather';
+
+const SideNavigation: React.FunctionComponent<{
+  active: NAVIGATION_LINKS;
+  data: {
+    notificationsCount: number;
+  };
+  onChange: (link: NAVIGATION_LINKS) => void;
+}> = ({ active, data, onChange }) => {
+  const epicsClassName = classnames({
+    'bg-teal-700': active === NAVIGATION_LINKS.EPICS,
+  });
+  const notificationsClassName = classnames({
+    'bg-teal-700': active === NAVIGATION_LINKS.NOTIFICATIONS,
+  });
+  const usersClassName = classnames({
+    'bg-teal-700': active === NAVIGATION_LINKS.USERS,
+  });
+
+  const commonClassName = 'p-4 cursor-pointer hover:bg-teal-700 hover:text-teal-700';
+  const iconSize = 20;
+
+  const { notificationsCount } = data;
+  return (
+    <div className="bg-teal-800 text-white">
+      <div
+        className={`${commonClassName} ${epicsClassName}`}
+        onClick={() => onChange(NAVIGATION_LINKS.EPICS)}
+      >
+        <Zap size={iconSize} className="mx-auto text-teal-400" />
+      </div>
+
+      <div
+        className={`${commonClassName} ${notificationsClassName}`}
+        onClick={() => onChange(NAVIGATION_LINKS.NOTIFICATIONS)}
+      >
+        <div className="p-2 relative">
+          <Bell size={iconSize} className="mx-auto text-teal-400" />
+
+          {notificationsCount > 0 && (
+            <div className="badge-sm absolute bottom-0 right-0 px-1 bg-red-600 text-white center rounded-full">
+              {notificationsCount}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div
+        className={`${commonClassName} ${usersClassName}`}
+        onClick={() => onChange(NAVIGATION_LINKS.USERS)}
+      >
+        <Users size={iconSize} className="mx-auto text-teal-400" />
+      </div>
+    </div>
+  );
+};
+
+export default SideNavigation;

--- a/src/components/SignUp.tsx
+++ b/src/components/SignUp.tsx
@@ -83,7 +83,7 @@ function SignUp() {
             </div>
             <div className="md:w-2/3">
               <input
-                type="text"
+                type="password"
                 name="confirmPassword"
                 ref={register({
                   validate: value => value === watch('password'),

--- a/src/components/Sprint.tsx
+++ b/src/components/Sprint.tsx
@@ -29,7 +29,7 @@ const Sprint: React.FunctionComponent<ISprint & ISprintProps> = ({
     event.preventDefault();
     const sprintName = event.currentTarget.sprintName.value;
     const capacity = event.currentTarget.capacity.value || 0;
-    const goal = event.currentTarget.goal.value || 0;
+    const goal = event.currentTarget.goal.value || '';
     delayedEdit({ id, name: sprintName, capacity, goal } as ISprint);
   };
 

--- a/src/components/Sprint.tsx
+++ b/src/components/Sprint.tsx
@@ -34,7 +34,7 @@ const Sprint: React.FunctionComponent<ISprint & ISprintProps> = ({
   };
 
   return (
-    <div className={` px-4 mb-4 pb-4 ${isLoading ? 'opacity-50' : ''}`}>
+    <div className={` px-4 mb-4 pb-4`}>
       <div className="flex flex-row items-center">
         <div>
           <div className="tag mr-2">{id}</div>

--- a/src/styles/x.css
+++ b/src/styles/x.css
@@ -101,7 +101,7 @@ textarea {
 }
 
 .clickable {
-  @apply text-gray-400 cursor-pointer;
+  @apply text-gray-500 cursor-pointer;
 }
 
 .clickable:hover {
@@ -212,6 +212,10 @@ textarea {
 
 .icon-parent > input:focus + .icon-child {
   @apply inline-block;
+}
+
+.badge-sm {
+  font-size: 0.6rem;
 }
 
 /** 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -84,10 +84,9 @@ interface Dep {
 }
 
 export interface ICrossDeps {
-  deps: { from: Dep, to: Dep }[];
+  deps: { from: Dep; to: Dep }[];
   maxSprint: number;
 }
-
 
 export interface IError {
   error?: {
@@ -127,4 +126,10 @@ export enum STORY_REQUEST_ACTION {
 export interface SelectOption {
   value: number | string;
   label: string;
+}
+
+export enum NAVIGATION_LINKS {
+  EPICS = 'EPICS',
+  NOTIFICATIONS = 'NOTIFICATIONS',
+  USERS = 'USERS',
 }

--- a/src/utils/Helpers.ts
+++ b/src/utils/Helpers.ts
@@ -163,6 +163,9 @@ export const countsPhrase = (word = '', items = []) => {
     case 'story': {
       return `${count} stor${count === 1 ? 'y' : 'ies'}`;
     }
+    case 'notification': {
+      return `${count} notification${count === 1 ? '' : 's'}`;
+    }
   }
 };
 


### PR DESCRIPTION
We're making the following changes:
1. A simple expandable Backlog
2. Sidebar navigation that's collapsible. This will pave way for other things we want added like Users or Objectives. Current design's layout is limited and inflexible to accommodate further addition of features in terms of layout space.

<img width="1680" alt="Screenshot 2020-03-25 at 7 28 44 PM" src="https://user-images.githubusercontent.com/743366/77532090-236f3e00-6ecf-11ea-8602-e9e7ded4f267.png">
