### PR TITLE
Use hooks and context to manage WebSocket connection

### DIFF
--- a/src/actions/boardActions.ts
+++ b/src/actions/boardActions.ts
@@ -206,3 +206,14 @@ export function fetchBoardDetails(boardId: number) {
     payload: { request: { data: { boardId } }, success: { data: {} } },
   } as const;
 }
+
+// WebsocketActions
+
+export function openedBoard(id: string, authToken) {
+  const message = { '@type': 'OpenedBoard', board: id, token: authToken };
+  return {
+    type: 'OPENED_BOARD',
+    message,
+    payload: { request: { data: { message } }, success: { board: {} as any } },
+  } as const;
+}

--- a/src/actions/boardActions.ts
+++ b/src/actions/boardActions.ts
@@ -3,6 +3,7 @@ import ApiService from 'utils/ApiService';
 import config from 'utils/config';
 import { ISprint, IStory, IBoard } from 'types';
 import { getNumberValue } from 'utils/Helpers';
+import { ISocketWrapper } from 'utils/WebSocketsService';
 
 export function deleteBoard(boardId: number) {
   return {
@@ -207,13 +208,22 @@ export function fetchBoardDetails(boardId: number) {
   } as const;
 }
 
+export function updateBoardIsInitialLoad(isInitialLoad: boolean) {
+  return {
+    type: 'UPDATE_BOARD_IS_INITIAL_LOAD',
+    payload: {
+      isInitialLoad,
+    },
+  };
+}
+
 // WebsocketActions
 
-export function openedBoard(id: string, authToken) {
-  const message = { type: 'OpenedBoard', board: id, token: authToken };
+export function openedBoard(id: string, socketWrapper: ISocketWrapper) {
+  const message = { type: 'OpenedBoard', board: id };
   return {
     type: 'OPENED_BOARD',
-    message,
+    sendMessage: () => socketWrapper.send(message),
     payload: { request: { data: { message } }, success: { board: {} as any } },
   } as const;
 }

--- a/src/actions/boardActions.ts
+++ b/src/actions/boardActions.ts
@@ -210,7 +210,7 @@ export function fetchBoardDetails(boardId: number) {
 // WebsocketActions
 
 export function openedBoard(id: string, authToken) {
-  const message = { '@type': 'OpenedBoard', board: id, token: authToken };
+  const message = { type: 'OpenedBoard', board: id, token: authToken };
   return {
     type: 'OPENED_BOARD',
     message,

--- a/src/actions/boardListActions.ts
+++ b/src/actions/boardListActions.ts
@@ -4,7 +4,7 @@ import { IBoard } from 'types';
 import { IBoardListItem } from 'store/IStoreState';
 
 export function openedBoardList(authToken) {
-  const message = { '@type': 'OpenedBoardList', token: authToken };
+  const message = { type: 'OpenedBoardList', token: authToken };
 
   return {
     type: 'OPENED_BOARD_LIST',

--- a/src/actions/boardListActions.ts
+++ b/src/actions/boardListActions.ts
@@ -1,6 +1,17 @@
 import ApiService from 'utils/ApiService';
 import config from 'utils/config';
 import { IBoard } from 'types';
+import { IBoardListItem } from 'store/IStoreState';
+
+export function openedBoardList(authToken) {
+  const message = { '@type': 'OpenedBoardList', token: authToken };
+
+  return {
+    type: 'OPENED_BOARD_LIST',
+    message,
+    payload: { request: {}, success: { boards: [] as IBoardListItem[] } },
+  } as const;
+}
 
 export function createBoard(boardName: string, ownerId: number) {
   const endpoint = `${config.API_URL}/boards`;

--- a/src/actions/boardListActions.ts
+++ b/src/actions/boardListActions.ts
@@ -3,12 +3,12 @@ import config from 'utils/config';
 import { IBoard } from 'types';
 import { IBoardListItem } from 'store/IStoreState';
 
-export function openedBoardList(authToken) {
-  const message = { type: 'OpenedBoardList', token: authToken };
+export function openedBoardList(socketWrapper) {
+  const message = { type: 'OpenedBoardList' };
 
   return {
     type: 'OPENED_BOARD_LIST',
-    message,
+    sendMessage: () => socketWrapper.send(message),
     payload: { request: {}, success: { boards: [] as IBoardListItem[] } },
   } as const;
 }
@@ -24,4 +24,13 @@ export function createBoard(boardName: string, ownerId: number) {
     callApi: () => ApiService.post(endpoint, { data }),
     payload: { request: {}, success: { data: {} as IBoard } },
   } as const;
+}
+
+export function updateIsInitialLoad(isInitialLoad: boolean) {
+  return {
+    type: 'UPDATE_BOARD_LIST_IS_INITIAL_LOAD',
+    payload: {
+      isInitialLoad,
+    },
+  };
 }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -20,7 +20,7 @@ import WebSocketsService from 'utils/WebSocketsService';
 
 toast.configure({ hideProgressBar: true });
 
-const messageToActionTypeMap = {
+const messageTypeToActionTypeMap = {
   Board: 'OPENED_BOARD',
   BoardList: 'OPENED_BOARD_LIST',
 };
@@ -39,15 +39,14 @@ export function App() {
 
   const onMessageCallback = event => {
     const data = JSON.parse(event.data);
-    const type = messageToActionTypeMap[data['@type']];
-    console.log('RECEIVING');
+    const type = messageTypeToActionTypeMap[data['@type']];
     dispatch(createReceiveWsAction(type, data));
   };
 
   useEffect(() => {
-    console.log('1111');
     actions.checkUserStatus(history).then(() => {
-      WebSocketsService.initWebSocketConnection(onMessageCallback);
+      WebSocketsService.initWebSocketConnection();
+      WebSocketsService.handleMessage(onMessageCallback);
     });
   }, []);
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -45,8 +45,8 @@ export function App() {
 
   useEffect(() => {
     actions.checkUserStatus(history).then(() => {
-      WebSocketsService.initWebSocketConnection();
       WebSocketsService.handleMessage(onMessageCallback);
+      WebSocketsService.initWebSocketConnection();
     });
   }, []);
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-named-as-default */
-import React, { useEffect } from 'react';
+import React, { useEffect, createContext, useState } from 'react';
 import { hot } from 'react-hot-loader';
 
 import { Route, Switch, withRouter, Redirect, useHistory } from 'react-router-dom';
@@ -16,7 +16,8 @@ import DependenciesView from 'components/DependenciesView';
 import { checkUserStatus } from 'actions/appLoad';
 import Board from 'components/Board';
 import { SquareSpinner } from 'styles/ThemeComponents';
-import WebSocketsService from 'utils/WebSocketsService';
+import { useWebSocket } from 'utils/WebSocketsService';
+import AuthService from 'utils/AuthService';
 
 toast.configure({ hideProgressBar: true });
 
@@ -31,6 +32,8 @@ const createReceiveWsAction = (type, data) => ({
   payload: { success: data },
 });
 
+export const SocketContext = createContext(null);
+
 export function App() {
   const myState = useSelector<IStoreState, IMyState>(state => state.myState);
   const history = useHistory();
@@ -43,12 +46,15 @@ export function App() {
     dispatch(createReceiveWsAction(type, data));
   };
 
+  const [userAuthToken, setUserAuthToken] = useState('');
+
   useEffect(() => {
     actions.checkUserStatus(history).then(() => {
-      WebSocketsService.handleMessage(onMessageCallback);
-      WebSocketsService.initWebSocketConnection();
+      setUserAuthToken(AuthService.getAuthToken());
     });
   }, []);
+
+  const [socket] = useWebSocket({ messageHandler: onMessageCallback, userAuthToken });
 
   const { isFetchingMe = false } = myState;
 
@@ -61,14 +67,16 @@ export function App() {
           </div>
         </div>
       ) : (
-        <Switch>
-          <Redirect exact path="/" to={'/login'} />
-          <Route exact path="/login" component={Login} />
-          <Route exact path="/signup" component={SignUp} />
-          <Route exact path="/boards" component={BoardList} />
-          <Route exact path="/boards/dependencies" component={DependenciesView} />
-          <Route exact path="/boards/:boardId" component={Board} />
-        </Switch>
+        <SocketContext.Provider value={{ socket }}>
+          <Switch>
+            <Redirect exact path="/" to={'/login'} />
+            <Route exact path="/login" component={Login} />
+            <Route exact path="/signup" component={SignUp} />
+            <Route exact path="/boards" component={BoardList} />
+            <Route exact path="/boards/dependencies" component={DependenciesView} />
+            <Route exact path="/boards/:boardId" component={Board} />
+          </Switch>
+        </SocketContext.Provider>
       )}
     </div>
   );

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -39,7 +39,7 @@ export function App() {
 
   const onMessageCallback = event => {
     const data = JSON.parse(event.data);
-    const type = messageTypeToActionTypeMap[data['@type']];
+    const type = messageTypeToActionTypeMap[data.type];
     dispatch(createReceiveWsAction(type, data));
   };
 

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -89,7 +89,6 @@ function Board() {
 
   useEffect(() => {
     refreshEpicsList();
-    // WebSockets.openedBoard(boardId);
     actions.openedBoard(boardId, AuthService.getAuthToken());
   }, []);
 

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,12 +1,4 @@
-import React, {
-  useEffect,
-  useState,
-  useRef,
-  createContext,
-  useMemo,
-  useCallback,
-  useLayoutEffect,
-} from 'react';
+import React, { useEffect, useState, useRef, createContext, useMemo, useCallback } from 'react';
 import hash from 'object-hash';
 
 import _ from 'lodash';
@@ -18,9 +10,7 @@ import { Link } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { ChevronLeft, X, ChevronRight } from 'react-feather';
-import moment from 'moment';
 import Loader from 'react-loader-spinner';
-import config from 'utils/config';
 
 import * as boardActions from 'actions/boardActions';
 import * as epicsActions from 'actions/epicsActions';
@@ -97,13 +87,10 @@ function Board() {
   );
   const { boardId } = useParams();
 
-  WebSockets.onBoardUpdate(board => {
-    dispatch({ type: 'FETCH_BOARD', payload: board });
-  });
-
   useEffect(() => {
     refreshEpicsList();
-    WebSockets.openedBoard(boardId);
+    // WebSockets.openedBoard(boardId);
+    actions.openedBoard(boardId, AuthService.getAuthToken());
   }, []);
 
   const refreshEpicsList = () => {

--- a/src/components/BoardList.tsx
+++ b/src/components/BoardList.tsx
@@ -70,13 +70,8 @@ function BoardList() {
   };
 
   useEffect(() => {
-    // WebSockets.openedBoardList();
-    console.log('2222');
     actions.openedBoardList(AuthService.getAuthToken());
   }, []);
-  // WebSockets.onBoardListUpdate(boards => {
-  //   dispatch({ type: 'FETCH_BOARD_LIST', payload: { success: { data: boards } } });
-  // });
 
   const { isFetching, data: boards = [] } = boardListState;
 

--- a/src/components/BoardList.tsx
+++ b/src/components/BoardList.tsx
@@ -8,7 +8,7 @@ import { Trash, Edit2, ChevronRight } from 'react-feather';
 import { useForm } from 'react-hook-form';
 
 import { deleteBoard } from 'actions/boardActions';
-import { createBoard } from 'actions/boardListActions';
+import { createBoard, openedBoardList } from 'actions/boardListActions';
 import { BoundActionsObjectMap } from 'actions/actionTypes';
 import IStoreState, { IBoardListState, IMyState } from 'store/IStoreState';
 import { IBoard } from '../types';
@@ -31,7 +31,7 @@ function BoardList() {
 
   const dispatch = useDispatch();
   const actions = bindActionCreators<{}, BoundActionsObjectMap>(
-    { createBoard, deleteBoard },
+    { createBoard, deleteBoard, openedBoardList },
     dispatch
   );
 
@@ -70,11 +70,13 @@ function BoardList() {
   };
 
   useEffect(() => {
-    WebSockets.openedBoardList();
+    // WebSockets.openedBoardList();
+    console.log('2222');
+    actions.openedBoardList(AuthService.getAuthToken());
   }, []);
-  WebSockets.onBoardListUpdate(boards => {
-    dispatch({ type: 'FETCH_BOARD_LIST', payload: { success: { data: boards } } });
-  });
+  // WebSockets.onBoardListUpdate(boards => {
+  //   dispatch({ type: 'FETCH_BOARD_LIST', payload: { success: { data: boards } } });
+  // });
 
   const { isFetching, data: boards = [] } = boardListState;
 

--- a/src/components/Socket.tsx
+++ b/src/components/Socket.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState, useRef, useContext, useMemo, useCallback } from 'react';
+import { SocketContext } from './App';
+import { ISocketWrapper } from 'utils/WebSocketsService';
+
+function Socket({ onOpen }: { onOpen: (socket: ISocketWrapper) => void }) {
+  const socketContext = useContext(SocketContext);
+
+  const { socket } = socketContext || {};
+
+  const socketReadyState = socket && socket.instance ? socket.instance.readyState : '';
+
+  useEffect(
+    () => {
+      if (socketReadyState === 1) {
+        onOpen(socket);
+      }
+    },
+    [socketReadyState]
+  );
+
+  return <div />;
+}
+
+export default Socket;

--- a/src/reducers/boardListState.ts
+++ b/src/reducers/boardListState.ts
@@ -18,6 +18,15 @@ const boardListState = (state: IBoardListState = initialState, action: Actions) 
         draft.data = data;
         return;
       }
+      case 'OPENED_BOARD_LIST': {
+        asyncActionReducer(draft, action, ['isFetching'], () => {
+          const { payload } = action;
+          const { success } = payload;
+          const { boards } = success;
+          draft.data = boards;
+        });
+        return;
+      }
       case 'CREATE_BOARD': {
         asyncActionReducer(draft, action, ['isCreating']);
         return;

--- a/src/reducers/boardListState.ts
+++ b/src/reducers/boardListState.ts
@@ -5,6 +5,7 @@ import produce from 'immer';
 import { asyncActionReducer } from 'utils/Helpers';
 const initialState = {
   data: [],
+  isInitialLoad: true,
   isFetching: false,
   isCreating: false,
   errorMessage: '',
@@ -13,6 +14,12 @@ const initialState = {
 const boardListState = (state: IBoardListState = initialState, action: Actions) =>
   produce(state, draft => {
     switch (action.type) {
+      case 'UPDATE_BOARD_LIST_IS_INITIAL_LOAD': {
+        const { payload } = action;
+        const { isInitialLoad: newIsInitialLoad } = payload;
+        draft.isInitialLoad = newIsInitialLoad;
+        return;
+      }
       case 'FETCH_BOARD_LIST': {
         const { data } = action.payload.success;
         draft.data = data;
@@ -24,6 +31,7 @@ const boardListState = (state: IBoardListState = initialState, action: Actions) 
           const { success } = payload;
           const { boards } = success;
           draft.data = boards;
+          draft.isInitialLoad = false;
         });
         return;
       }

--- a/src/reducers/boardState.ts
+++ b/src/reducers/boardState.ts
@@ -30,6 +30,13 @@ const initialState = {
 const boardListState = (state: IBoardState = initialState, action: Actions) =>
   produce(state, draft => {
     switch (action.type) {
+      case 'OPENED_BOARD': {
+        asyncActionReducer(draft, action, ['isFetching'], () => {
+          const { board } = action.payload.success;
+          draft.data = board;
+        });
+        return;
+      }
       case 'SOLVE': {
         asyncActionReducer(draft, action, ['isSolving'], () => {
           const { data } = action.payload.success;

--- a/src/reducers/boardState.ts
+++ b/src/reducers/boardState.ts
@@ -8,6 +8,7 @@ import { addDependency, deleteDependency } from 'types/utility';
 const initialState = {
   data: {},
   isSolving: false,
+  isInitialLoad: true,
   isFetching: false,
   isUpdatingBoard: false,
   isAddingDependency: false,
@@ -27,13 +28,20 @@ const initialState = {
   },
 };
 
-const boardListState = (state: IBoardState = initialState, action: Actions) =>
+const boardState = (state: IBoardState = initialState, action: Actions) =>
   produce(state, draft => {
     switch (action.type) {
+      case 'UPDATE_BOARD_IS_INITIAL_LOAD': {
+        const { payload } = action;
+        const { isInitialLoad: newIsInitialLoad } = payload;
+        draft.isInitialLoad = newIsInitialLoad;
+        return;
+      }
       case 'OPENED_BOARD': {
         asyncActionReducer(draft, action, ['isFetching'], () => {
           const { board } = action.payload.success;
           draft.data = board;
+          draft.isInitialLoad = false;
         });
         return;
       }
@@ -56,38 +64,24 @@ const boardListState = (state: IBoardState = initialState, action: Actions) =>
         return;
       }
       case 'CREATE_SPRINT': {
-        asyncActionReducer(draft, action, ['isCreatingSprint'], () => {
-          const { data: newSprint } = action.payload.success;
-          draft.data.sprints = [...draft.data.sprints, newSprint];
-        });
+        asyncActionReducer(draft, action, ['isCreatingSprint']);
         return;
       }
       case 'DELETE_SPRINT': {
         const { data } = action.payload.request;
         const { id } = data;
-        asyncActionReducerById(draft, action, id, ['sprintAsyncCallStateById'], () => {
-          draft.data.sprints =
-            draft.data.sprints && draft.data.sprints.filter(sprint => sprint.id !== id);
-        });
+        asyncActionReducerById(draft, action, id, ['sprintAsyncCallStateById']);
         return;
       }
       case 'UPDATE_SPRINT': {
         const { data } = action.payload.request;
         const { sprint } = data;
-        const { id, name, capacity } = sprint;
-        asyncActionReducerById(draft, action, id, ['sprintAsyncCallStateById'], () => {
-          // BE currently does not return updated Sprint.
-          const sprintIndex = draft.data.sprints.findIndex(s => s.id === id);
-          draft.data.sprints[sprintIndex].name = name;
-          draft.data.sprints[sprintIndex].capacity = capacity;
-        });
+        const { id } = sprint;
+        asyncActionReducerById(draft, action, id, ['sprintAsyncCallStateById']);
         return;
       }
       case 'CREATE_STORY': {
-        asyncActionReducer(draft, action, ['isCreatingStory'], () => {
-          const { data: newStory } = action.payload.success;
-          draft.data.unassigned = [...draft.data.unassigned, newStory]; // Current design simply adds story to backlog
-        });
+        asyncActionReducer(draft, action, ['isCreatingStory']);
         return;
       }
       case 'UPDATE_STORY': {
@@ -95,27 +89,7 @@ const boardListState = (state: IBoardState = initialState, action: Actions) =>
         const { story } = data;
 
         const { id: storyId } = story;
-        asyncActionReducerById(draft, action, storyId, ['storyAsyncCallStateById'], () => {
-          // BE currently does not return updated Sprint.
-          const sprintIndex = _.findIndex(draft.data.sprints, { tickets: [{ id: storyId }] });
-          let ticketIndex;
-
-          // When story/ticket is found in sprints, find ticket index from its sprint.
-          // Look for story/ticket in unassigned/backlogs.
-          if (sprintIndex >= 0) {
-            ticketIndex = _.findIndex(draft.data.sprints[sprintIndex].tickets, { id: storyId });
-            draft.data.sprints[sprintIndex].tickets[ticketIndex] = {
-              ...draft.data.sprints[sprintIndex].tickets[ticketIndex],
-              ...story,
-            };
-          } else {
-            ticketIndex = _.findIndex(draft.data.unassigned, { id: storyId });
-            draft.data.unassigned[ticketIndex] = {
-              ...draft.data.unassigned[ticketIndex],
-              ...story,
-            };
-          }
-        });
+        asyncActionReducerById(draft, action, storyId, ['storyAsyncCallStateById']);
         return;
       }
       case 'ADD_DEPENDENCY': {
@@ -162,4 +136,4 @@ const boardListState = (state: IBoardState = initialState, action: Actions) =>
     }
   });
 
-export default boardListState;
+export default boardState;

--- a/src/store/IStoreState.ts
+++ b/src/store/IStoreState.ts
@@ -20,6 +20,7 @@ export interface IDependenciesViewState {
 
 export interface IBoardListState {
   data?: IBoardListItem[];
+  isInitialLoad?: boolean;
   isFetching?: boolean;
   errorMessage?: string;
 }
@@ -46,6 +47,7 @@ export interface IEpicsListState {
 
 export interface IBoardState {
   data?: IBoard;
+  isInitialLoad?: boolean;
   isSolving?: boolean;
   isFetching?: boolean;
   isUpdatingBoard?: boolean;

--- a/src/utils/Middlewares.ts
+++ b/src/utils/Middlewares.ts
@@ -5,7 +5,6 @@ import WebSocketsService from './WebSocketsService';
 // and tweaked
 export const actionsMiddleware = ({ dispatch }) => next => action => {
   const { type, callApi, message, payload = {} } = action;
-  console.log(action);
 
   if (!callApi && !message) {
     // Normal action: pass it on

--- a/src/utils/Middlewares.ts
+++ b/src/utils/Middlewares.ts
@@ -1,12 +1,11 @@
 import { getError } from 'utils/Helpers';
-import WebSocketsService from './WebSocketsService';
 
 // Borrowed from https://redux.js.org/recipes/reducing-boilerplate
 // and tweaked
 export const actionsMiddleware = ({ dispatch }) => next => action => {
-  const { type, callApi, message, payload = {} } = action;
+  const { type, callApi, sendMessage, payload = {} } = action;
 
-  if (!callApi && !message) {
+  if (!callApi && !sendMessage) {
     // Normal action: pass it on
     return next(action);
   }
@@ -55,7 +54,7 @@ export const actionsMiddleware = ({ dispatch }) => next => action => {
 
         throw errorMessage;
       });
-  } else if (message) {
-    WebSocketsService.send(message);
+  } else if (sendMessage) {
+    sendMessage();
   }
 };

--- a/src/utils/WebSocketsService.ts
+++ b/src/utils/WebSocketsService.ts
@@ -1,71 +1,105 @@
 import config from './config';
+import { useState, useEffect } from 'react';
 
-let socket;
-let messageHandler;
-let connected = false;
+/**
+ * This hook exposes SocketWrapper containing an instance of the created WebSocket object
+ * and the send function. `send` function "wraps" WebSocket's `send` to add
+ * checks on the socket before performing actual send.
+ *
+ * @param props { messageHandler, userAuthToken }
+ */
+export function useWebSocket(props) {
+  const { messageHandler, userAuthToken } = props || {};
 
-function initWebSocketConnection() {
-  // This has to be idempotent because it's called from every page's useEffect.
-  // That is done because on hot reload, socket will be set to null, causing everything to break.
-  if (socket) {
-    return Promise.resolve();
-  }
+  /**
+   * Main instance of websocket which events and states are tracked.
+   * This is stored in the instance property of the SocketWrapper - the object that
+   * is passed as a value to the SocketContext defined in the App.tsx
+   */
+  const [instance, setInstance] = useState<WebSocket>(null);
 
-  socket = new WebSocket(`${config.WS_URL}/ws`);
-  socket.binaryType = 'arraybuffer';
+  const [readyState, setReadyState] = useState(undefined);
 
-  const p = new Promise((resolve, _) => {
-    socket.onopen = function() {
-      connected = true;
-      resolve();
-    };
+  /**
+   * socketWrapper state stores the current instance and the `send` function.
+   * `send` function is run the MiddleWare executes `sendMessage()` defined in
+   * a WebSocket-supported action creator (ie, boardActions#openedBoard)
+   */
+  const [socketWrapper, setSocketWrapper] = useState<ISocketWrapper>({
+    instance,
+    send: () => {}, // Noop
   });
 
-  socket.onmessage = event => {
-    messageHandler(event);
-  };
+  /**
+   * This useEffect is to instatiate and track the active WebSocket instance
+   */
+  useEffect(
+    () => {
+      if (!instance) {
+        const ws = new WebSocket(`${config.WS_URL}/ws`);
+        ws.binaryType = 'arraybuffer';
 
-  socket.onclose = function() {
-    // Try to reconnect
-    connected = false;
-    initWebSocketConnection();
-  };
+        ws.onopen = function() {
+          setReadyState(ws.readyState);
+        };
 
-  return p;
+        ws.onmessage = event => {
+          if (messageHandler) {
+            messageHandler(event);
+          }
+        };
+
+        ws.onclose = function() {
+          setReadyState(ws.readyState);
+          // Try to reconnect
+          // We handle reconnection by detecting CLOSED readyState in useEffect below
+        };
+
+        setInstance(ws);
+      }
+    },
+    [instance]
+  );
+
+  /**
+   * Closes socket instance and nullifies instance's readyState is CLOSED (3)
+   * This kickoffs useEffect above
+   */
+  useEffect(
+    () => {
+      if (readyState === 3) {
+        instance.close();
+        setInstance(null);
+      }
+    },
+    [readyState]
+  );
+
+  /**
+   * Creates and sets SocketWrapper when instance and userAuthToken changes.
+   * This useEffect is primarily to instatiate the SocketWrapper and supply
+   * the updated userAuthToken hence separated for its purpose.
+   */
+  useEffect(
+    () => {
+      if (instance) {
+        setSocketWrapper({
+          instance,
+          send: message => {
+            if (instance && userAuthToken) {
+              instance.send(JSON.stringify({ ...message, token: userAuthToken }));
+            }
+          },
+        });
+      }
+    },
+    [instance, userAuthToken]
+  );
+
+  return [socketWrapper];
 }
 
-async function send(message) {
-  // Lazily initialize connection
-  await initWebSocketConnection();
-  if (socket && socket.readyState === 1) {
-    socket.send(JSON.stringify(message));
-  }
+export interface ISocketWrapper {
+  instance: WebSocket;
+  send: (message: Object) => void;
 }
-
-// The socket is nulled when hot reloading, but the underlying connection persists.
-// We need to explicitly get rid of it.
-if (module.hot) {
-  module.hot.dispose(_ => {
-    if (socket) {
-      socket.close();
-      socket = null;
-    }
-  });
-}
-
-function isConnected() {
-  return connected;
-}
-
-function handleMessage(fn) {
-  messageHandler = fn;
-}
-
-// And these are for acting on the messages which come in
-
-export default {
-  handleMessage,
-  initWebSocketConnection,
-  isConnected,
-  send,
-};

--- a/src/utils/WebSocketsService.ts
+++ b/src/utils/WebSocketsService.ts
@@ -1,59 +1,70 @@
 import config from './config';
-import AuthService from './AuthService';
 
 let socket;
-let boardUpdateCallback, boardListUpdateCallback;
+let messageHandler;
 let connected = false;
 
-function initWebSocketConnection(onMessageCallback) {
-  console.log(socket ? socket.readyState : '');
+function initWebSocketConnection() {
+  // This has to be idempotent because it's called from every page's useEffect.
+  // That is done because on hot reload, socket will be set to null, causing everything to break.
+  if (socket) {
+    return Promise.resolve();
+  }
+
   socket = new WebSocket(`${config.WS_URL}/ws`);
   socket.binaryType = 'arraybuffer';
 
-  socket.onopen = function() {
-    console.log(socket ? socket.readyState : '');
+  const p = new Promise((resolve, _) => {
+    socket.onopen = function() {
+      connected = true;
+      resolve();
+    };
+  });
 
-    connected = true;
+  socket.onmessage = event => {
+    messageHandler(event);
   };
-  console.log(socket ? socket.readyState : '');
-
-  socket.onmessage = onMessageCallback;
 
   socket.onclose = function() {
     // Try to reconnect
-    console.log(socket ? socket.readyState : '');
-    socket.close();
     connected = false;
-    initWebSocketConnection(onMessageCallback);
+    initWebSocketConnection();
   };
+
+  return p;
 }
 
-function send(message) {
+async function send(message) {
   // Lazily initialize connection
-  // await initWebSocketConnection();
+  await initWebSocketConnection();
   if (socket && socket.readyState === 1) {
     socket.send(JSON.stringify(message));
   }
 }
 
-// // The socket is nulled when hot reloading, but the underlying connection persists.
-// // We need to explicitly get rid of it.
-// if (module.hot) {
-//   module.hot.dispose(_ => {
-//     if (socket) {
-//       socket.close();
-//       socket = null;
-//     }
-//   });
-// }
+// The socket is nulled when hot reloading, but the underlying connection persists.
+// We need to explicitly get rid of it.
+if (module.hot) {
+  module.hot.dispose(_ => {
+    if (socket) {
+      socket.close();
+      socket = null;
+    }
+  });
+}
 
 function isConnected() {
   return connected;
 }
 
+function handleMessage(fn) {
+  messageHandler = fn;
+}
+
 // And these are for acting on the messages which come in
 
 export default {
+  handleMessage,
   initWebSocketConnection,
   isConnected,
   send,


### PR DESCRIPTION
This PR includes the following:
1. `useWebSocket` hook that handles the instantiation and tracking of WebSocket instance.
2. Removal of the handling the REST response in the reducers since we are now handling messages from the socket instead through `OPENED_BOARD` action. 