### PR TITLE
Use hooks to manage connection

### DIFF
--- a/src/actions/boardActions.ts
+++ b/src/actions/boardActions.ts
@@ -3,6 +3,7 @@ import ApiService from 'utils/ApiService';
 import config from 'utils/config';
 import { ISprint, IStory, IBoard } from 'types';
 import { getNumberValue } from 'utils/Helpers';
+import { ISocketWrapper } from 'utils/WebSocketsService';
 
 export function deleteBoard(boardId: number) {
   return {
@@ -207,13 +208,22 @@ export function fetchBoardDetails(boardId: number) {
   } as const;
 }
 
+export function updateBoardIsInitialLoad(isInitialLoad: boolean) {
+  return {
+    type: 'UPDATE_BOARD_IS_INITIAL_LOAD',
+    payload: {
+      isInitialLoad,
+    },
+  };
+}
+
 // WebsocketActions
 
-export function openedBoard(id: string, authToken) {
-  const message = { '@type': 'OpenedBoard', board: id, token: authToken };
+export function openedBoard(id: string, socketWrapper: ISocketWrapper) {
+  const message = { '@type': 'OpenedBoard', board: id };
   return {
     type: 'OPENED_BOARD',
-    message,
+    sendMessage: () => socketWrapper.send(message),
     payload: { request: { data: { message } }, success: { board: {} as any } },
   } as const;
 }

--- a/src/actions/boardActions.ts
+++ b/src/actions/boardActions.ts
@@ -220,7 +220,7 @@ export function updateBoardIsInitialLoad(isInitialLoad: boolean) {
 // WebsocketActions
 
 export function openedBoard(id: string, socketWrapper: ISocketWrapper) {
-  const message = { '@type': 'OpenedBoard', board: id };
+  const message = { type: 'OpenedBoard', board: id };
   return {
     type: 'OPENED_BOARD',
     sendMessage: () => socketWrapper.send(message),

--- a/src/actions/boardListActions.ts
+++ b/src/actions/boardListActions.ts
@@ -3,12 +3,12 @@ import config from 'utils/config';
 import { IBoard } from 'types';
 import { IBoardListItem } from 'store/IStoreState';
 
-export function openedBoardList(authToken) {
-  const message = { '@type': 'OpenedBoardList', token: authToken };
+export function openedBoardList(socketWrapper) {
+  const message = { '@type': 'OpenedBoardList' };
 
   return {
     type: 'OPENED_BOARD_LIST',
-    message,
+    sendMessage: () => socketWrapper.send(message),
     payload: { request: {}, success: { boards: [] as IBoardListItem[] } },
   } as const;
 }
@@ -24,4 +24,13 @@ export function createBoard(boardName: string, ownerId: number) {
     callApi: () => ApiService.post(endpoint, { data }),
     payload: { request: {}, success: { data: {} as IBoard } },
   } as const;
+}
+
+export function updateIsInitialLoad(isInitialLoad: boolean) {
+  return {
+    type: 'UPDATE_BOARD_LIST_IS_INITIAL_LOAD',
+    payload: {
+      isInitialLoad,
+    },
+  };
 }

--- a/src/actions/boardListActions.ts
+++ b/src/actions/boardListActions.ts
@@ -4,7 +4,7 @@ import { IBoard } from 'types';
 import { IBoardListItem } from 'store/IStoreState';
 
 export function openedBoardList(socketWrapper) {
-  const message = { '@type': 'OpenedBoardList' };
+  const message = { type: 'OpenedBoardList' };
 
   return {
     type: 'OPENED_BOARD_LIST',

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -16,7 +16,7 @@ import DependenciesView from 'components/DependenciesView';
 import { checkUserStatus } from 'actions/appLoad';
 import Board from 'components/Board';
 import { SquareSpinner } from 'styles/ThemeComponents';
-import WebSocketsService, { useWebSocket } from 'utils/WebSocketsService';
+import { useWebSocket } from 'utils/WebSocketsService';
 import AuthService from 'utils/AuthService';
 
 toast.configure({ hideProgressBar: true });

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -73,10 +73,8 @@ export function App() {
             <Route exact path="/login" component={Login} />
             <Route exact path="/signup" component={SignUp} />
             <Route exact path="/boards" component={BoardList} />
-            {/* <Route exact path="/boards" component={() => <BoardList socket={socket} />} /> */}
             <Route exact path="/boards/dependencies" component={DependenciesView} />
             <Route exact path="/boards/:boardId" component={Board} />
-            {/* <Route exact path="/boards/:boardId" component={() => <Board socket={socket} />} /> */}
           </Switch>
         </SocketContext.Provider>
       )}

--- a/src/components/Socket.tsx
+++ b/src/components/Socket.tsx
@@ -5,7 +5,7 @@ import { ISocketWrapper } from 'utils/WebSocketsService';
 function Socket({ onOpen }: { onOpen: (socket: ISocketWrapper) => void }) {
   const socketContext = useContext(SocketContext);
 
-  const { socket } = socketContext;
+  const { socket } = socketContext || {};
 
   const socketReadyState = socket && socket.instance ? socket.instance.readyState : '';
 

--- a/src/components/Socket.tsx
+++ b/src/components/Socket.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState, useRef, useContext, useMemo, useCallback } from 'react';
+import { SocketContext } from './App';
+import { ISocketWrapper } from 'utils/WebSocketsService';
+
+function Socket({ onOpen }: { onOpen: (socket: ISocketWrapper) => void }) {
+  const socketContext = useContext(SocketContext);
+
+  const { socket } = socketContext;
+
+  const socketReadyState = socket && socket.instance ? socket.instance.readyState : '';
+
+  useEffect(
+    () => {
+      if (socketReadyState === 1) {
+        onOpen(socket);
+      }
+    },
+    [socketReadyState]
+  );
+
+  return <div />;
+}
+
+export default Socket;

--- a/src/reducers/boardListState.ts
+++ b/src/reducers/boardListState.ts
@@ -5,6 +5,7 @@ import produce from 'immer';
 import { asyncActionReducer } from 'utils/Helpers';
 const initialState = {
   data: [],
+  isInitialLoad: true,
   isFetching: false,
   isCreating: false,
   errorMessage: '',
@@ -13,6 +14,12 @@ const initialState = {
 const boardListState = (state: IBoardListState = initialState, action: Actions) =>
   produce(state, draft => {
     switch (action.type) {
+      case 'UPDATE_BOARD_LIST_IS_INITIAL_LOAD': {
+        const { payload } = action;
+        const { isInitialLoad: newIsInitialLoad } = payload;
+        draft.isInitialLoad = newIsInitialLoad;
+        return;
+      }
       case 'FETCH_BOARD_LIST': {
         const { data } = action.payload.success;
         draft.data = data;
@@ -24,6 +31,7 @@ const boardListState = (state: IBoardListState = initialState, action: Actions) 
           const { success } = payload;
           const { boards } = success;
           draft.data = boards;
+          draft.isInitialLoad = false;
         });
         return;
       }

--- a/src/reducers/boardState.ts
+++ b/src/reducers/boardState.ts
@@ -64,38 +64,24 @@ const boardState = (state: IBoardState = initialState, action: Actions) =>
         return;
       }
       case 'CREATE_SPRINT': {
-        asyncActionReducer(draft, action, ['isCreatingSprint'], () => {
-          const { data: newSprint } = action.payload.success;
-          draft.data.sprints = [...draft.data.sprints, newSprint];
-        });
+        asyncActionReducer(draft, action, ['isCreatingSprint']);
         return;
       }
       case 'DELETE_SPRINT': {
         const { data } = action.payload.request;
         const { id } = data;
-        asyncActionReducerById(draft, action, id, ['sprintAsyncCallStateById'], () => {
-          draft.data.sprints =
-            draft.data.sprints && draft.data.sprints.filter(sprint => sprint.id !== id);
-        });
+        asyncActionReducerById(draft, action, id, ['sprintAsyncCallStateById']);
         return;
       }
       case 'UPDATE_SPRINT': {
         const { data } = action.payload.request;
         const { sprint } = data;
-        const { id, name, capacity } = sprint;
-        asyncActionReducerById(draft, action, id, ['sprintAsyncCallStateById'], () => {
-          // BE currently does not return updated Sprint.
-          const sprintIndex = draft.data.sprints.findIndex(s => s.id === id);
-          draft.data.sprints[sprintIndex].name = name;
-          draft.data.sprints[sprintIndex].capacity = capacity;
-        });
+        const { id } = sprint;
+        asyncActionReducerById(draft, action, id, ['sprintAsyncCallStateById']);
         return;
       }
       case 'CREATE_STORY': {
-        asyncActionReducer(draft, action, ['isCreatingStory'], () => {
-          const { data: newStory } = action.payload.success;
-          draft.data.unassigned = [...draft.data.unassigned, newStory]; // Current design simply adds story to backlog
-        });
+        asyncActionReducer(draft, action, ['isCreatingStory']);
         return;
       }
       case 'UPDATE_STORY': {
@@ -103,27 +89,7 @@ const boardState = (state: IBoardState = initialState, action: Actions) =>
         const { story } = data;
 
         const { id: storyId } = story;
-        asyncActionReducerById(draft, action, storyId, ['storyAsyncCallStateById'], () => {
-          // BE currently does not return updated Sprint.
-          const sprintIndex = _.findIndex(draft.data.sprints, { tickets: [{ id: storyId }] });
-          let ticketIndex;
-
-          // When story/ticket is found in sprints, find ticket index from its sprint.
-          // Look for story/ticket in unassigned/backlogs.
-          if (sprintIndex >= 0) {
-            ticketIndex = _.findIndex(draft.data.sprints[sprintIndex].tickets, { id: storyId });
-            draft.data.sprints[sprintIndex].tickets[ticketIndex] = {
-              ...draft.data.sprints[sprintIndex].tickets[ticketIndex],
-              ...story,
-            };
-          } else {
-            ticketIndex = _.findIndex(draft.data.unassigned, { id: storyId });
-            draft.data.unassigned[ticketIndex] = {
-              ...draft.data.unassigned[ticketIndex],
-              ...story,
-            };
-          }
-        });
+        asyncActionReducerById(draft, action, storyId, ['storyAsyncCallStateById']);
         return;
       }
       case 'ADD_DEPENDENCY': {

--- a/src/reducers/boardState.ts
+++ b/src/reducers/boardState.ts
@@ -8,6 +8,7 @@ import { addDependency, deleteDependency } from 'types/utility';
 const initialState = {
   data: {},
   isSolving: false,
+  isInitialLoad: true,
   isFetching: false,
   isUpdatingBoard: false,
   isAddingDependency: false,
@@ -27,13 +28,20 @@ const initialState = {
   },
 };
 
-const boardListState = (state: IBoardState = initialState, action: Actions) =>
+const boardState = (state: IBoardState = initialState, action: Actions) =>
   produce(state, draft => {
     switch (action.type) {
+      case 'UPDATE_BOARD_IS_INITIAL_LOAD': {
+        const { payload } = action;
+        const { isInitialLoad: newIsInitialLoad } = payload;
+        draft.isInitialLoad = newIsInitialLoad;
+        return;
+      }
       case 'OPENED_BOARD': {
         asyncActionReducer(draft, action, ['isFetching'], () => {
           const { board } = action.payload.success;
           draft.data = board;
+          draft.isInitialLoad = false;
         });
         return;
       }
@@ -162,4 +170,4 @@ const boardListState = (state: IBoardState = initialState, action: Actions) =>
     }
   });
 
-export default boardListState;
+export default boardState;

--- a/src/store/IStoreState.ts
+++ b/src/store/IStoreState.ts
@@ -20,6 +20,7 @@ export interface IDependenciesViewState {
 
 export interface IBoardListState {
   data?: IBoardListItem[];
+  isInitialLoad?: boolean;
   isFetching?: boolean;
   errorMessage?: string;
 }
@@ -46,6 +47,7 @@ export interface IEpicsListState {
 
 export interface IBoardState {
   data?: IBoard;
+  isInitialLoad?: boolean;
   isSolving?: boolean;
   isFetching?: boolean;
   isUpdatingBoard?: boolean;

--- a/src/utils/Middlewares.ts
+++ b/src/utils/Middlewares.ts
@@ -1,12 +1,11 @@
 import { getError } from 'utils/Helpers';
-import WebSocketsService from './WebSocketsService';
 
 // Borrowed from https://redux.js.org/recipes/reducing-boilerplate
 // and tweaked
 export const actionsMiddleware = ({ dispatch }) => next => action => {
-  const { type, callApi, message, payload = {} } = action;
+  const { type, callApi, sendMessage, payload = {} } = action;
 
-  if (!callApi && !message) {
+  if (!callApi && !sendMessage) {
     // Normal action: pass it on
     return next(action);
   }
@@ -55,7 +54,7 @@ export const actionsMiddleware = ({ dispatch }) => next => action => {
 
         throw errorMessage;
       });
-  } else if (message) {
-    WebSocketsService.send(message);
+  } else if (sendMessage) {
+    sendMessage();
   }
 };

--- a/src/utils/WebSocketsService.ts
+++ b/src/utils/WebSocketsService.ts
@@ -1,84 +1,10 @@
 import config from './config';
 import { useState, useEffect } from 'react';
 
-let socket;
-let messageHandler;
-let connected = false;
-
-function initWebSocketConnection() {
-  // This has to be idempotent because it's called from every page's useEffect.
-  // That is done because on hot reload, socket will be set to null, causing everything to break.
-  if (socket && socket.readyState === 1) {
-    return Promise.resolve();
-  }
-
-  if (socket) {
-    socket.close();
-  }
-
-  socket = new WebSocket(`${config.WS_URL}/ws`);
-  socket.binaryType = 'arraybuffer';
-
-  const p = new Promise((resolve, _) => {
-    socket.onopen = function() {
-      connected = true;
-      resolve();
-    };
-  });
-
-  socket.onmessage = event => {
-    messageHandler(event);
-  };
-
-  socket.onclose = function() {
-    // Try to reconnect
-    connected = false;
-    initWebSocketConnection();
-  };
-
-  return p;
-}
-
-async function send(message) {
-  // Lazily initialize connection
-  await initWebSocketConnection();
-  if (socket && socket.readyState === 1) {
-    socket.send(JSON.stringify(message));
-  }
-}
-
-// The socket is nulled when hot reloading, but the underlying connection persists.
-// We need to explicitly get rid of it.
-if (module.hot) {
-  module.hot.dispose(_ => {
-    if (socket) {
-      socket.close();
-      socket = null;
-    }
-  });
-}
-
-function isConnected() {
-  return connected;
-}
-
-function handleMessage(fn) {
-  messageHandler = fn;
-}
-
-// And these are for acting on the messages which come in
-
-export default {
-  handleMessage,
-  initWebSocketConnection,
-  isConnected,
-  send,
-};
-
 /**
  * This hook exposes SocketWrapper containing an instance of the created WebSocket object
  * and the send function. `send` function "wraps" WebSocket's `send` to add
- * checks on the socket object's ready state before performing actual send.
+ * checks on the socket before performing actual send.
  *
  * @param props { messageHandler, userAuthToken }
  */

--- a/src/utils/WebSocketsService.ts
+++ b/src/utils/WebSocketsService.ts
@@ -1,4 +1,5 @@
 import config from './config';
+import { useState, useEffect } from 'react';
 
 let socket;
 let messageHandler;
@@ -7,8 +8,12 @@ let connected = false;
 function initWebSocketConnection() {
   // This has to be idempotent because it's called from every page's useEffect.
   // That is done because on hot reload, socket will be set to null, causing everything to break.
-  if (socket) {
+  if (socket && socket.readyState === 1) {
     return Promise.resolve();
+  }
+
+  if (socket) {
+    socket.close();
   }
 
   socket = new WebSocket(`${config.WS_URL}/ws`);
@@ -69,3 +74,106 @@ export default {
   isConnected,
   send,
 };
+
+/**
+ * This hook exposes SocketWrapper containing an instance of the created WebSocket object
+ * and the send function. `send` function "wraps" WebSocket's `send` to add
+ * checks on the socket object's ready state before performing actual send.
+ *
+ * @param props { messageHandler, userAuthToken }
+ */
+export function useWebSocket(props) {
+  const { messageHandler, userAuthToken } = props || {};
+
+  /**
+   * Main instance of websocket which events and states are tracked.
+   * This is stored in the instance property of the SocketWrapper - the object that
+   * is passed as a value to the SocketContext defined in the App.tsx
+   */
+  const [instance, setInstance] = useState<WebSocket>(null);
+
+  const [readyState, setReadyState] = useState(undefined);
+
+  const sendFn = (i: WebSocket, token: string) => {
+    return message => {
+      if (i) {
+        i.send(JSON.stringify({ ...message, token }));
+      }
+    };
+  };
+
+  /**
+   * socketWrapper state stores the current instance and the `send` function.
+   * `send` function is run the MiddleWare executes `sendMessage()` defined in
+   * a WebSocket-supported action creator (ie, boardActions#openedBoard)
+   */
+  const [socketWrapper, setSocketWrapper] = useState<ISocketWrapper>({
+    instance,
+    send: sendFn(instance, userAuthToken),
+  });
+
+  useEffect(
+    () => {
+      if (!instance) {
+        const ws = new WebSocket(`${config.WS_URL}/ws`);
+        ws.binaryType = 'arraybuffer';
+
+        ws.onopen = function() {
+          setReadyState(ws.readyState);
+        };
+
+        ws.onmessage = event => {
+          if (messageHandler) {
+            messageHandler(event);
+          }
+        };
+
+        ws.onclose = function() {
+          setReadyState(ws.readyState);
+
+          // Try to reconnect
+          // We handle reconnection by detecting CLOSED readyState in useEffect below
+        };
+
+        setInstance(ws);
+      }
+    },
+    [instance]
+  );
+
+  /**
+   * Closes socket instance and nullifies instance's readyState is CLOSED (3)
+   * This kickoffs useEffect above
+   */
+  useEffect(
+    () => {
+      if (readyState === 3) {
+        instance.close();
+        setInstance(null);
+      }
+    },
+    [readyState]
+  );
+
+  /**
+   * Creates and sets SocketWrapper when instance and userAuthToken changes
+   */
+  useEffect(
+    () => {
+      if (instance) {
+        setSocketWrapper({
+          instance,
+          send: sendFn(instance, userAuthToken),
+        });
+      }
+    },
+    [instance, userAuthToken]
+  );
+
+  return [socketWrapper];
+}
+
+export interface ISocketWrapper {
+  instance: WebSocket;
+  send: (message: Object) => void;
+}


### PR DESCRIPTION
This is the _hooks_ approach to creating WebSocket connection(and re-connection). Here, we pass `ISocketWrapper` around which contains `WebSocket` instance and a custom send function. We create and use a context called `SocketContext` to pass the socket wrapper which is consumed by a `Socket` component. `Socket` component handles changes in `readyState` of the supplied socket wrapper and provides the parent component (ie Board, BoardsList) the socket through `Socket`'s `onOpen` callback.

Other changes include letting the hook manage the `token` instead of having it supplied each time a message is to be sent.

Note that this is a branch out from the `wip-connection`

## Thanks!

:heart:
